### PR TITLE
Feat: 채팅 참여자 목록 조회 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -897,6 +897,20 @@ include::{snippets}/get-my-review/response-fields.adoc[]
 
 '''
 
+=== *채팅방 참여자 목록 조회*
+
+==== *요청*
+
+include::{snippets}/participant-list/http-request.adoc[]
+include::{snippets}/participant-list/path-parameters.adoc[]
+
+==== *응답*
+
+include::{snippets}/participant-list/http-response.adoc[]
+include::{snippets}/participant-list/response-fields.adoc[]
+
+'''
+
 === *작성할 리뷰 참여자 목록 조회*
 
 ==== *요청*

--- a/src/main/java/com/boardgo/domain/mapper/MeetingParticipantMapper.java
+++ b/src/main/java/com/boardgo/domain/mapper/MeetingParticipantMapper.java
@@ -1,9 +1,12 @@
 package com.boardgo.domain.mapper;
 
-import com.boardgo.domain.meeting.entity.MeetingParticipantEntity;
-import com.boardgo.domain.meeting.entity.enums.ParticipantType;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
+
+import com.boardgo.domain.meeting.entity.MeetingParticipantEntity;
+import com.boardgo.domain.meeting.entity.enums.ParticipantType;
+import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
+import com.boardgo.domain.user.repository.projection.UserParticipantProjection;
 
 @Mapper
 public interface MeetingParticipantMapper {
@@ -11,4 +14,7 @@ public interface MeetingParticipantMapper {
 
     MeetingParticipantEntity toMeetingParticipantEntity(
             Long meetingId, Long userInfoId, ParticipantType type);
+
+    UserParticipantResponse toUserParticipantResponse(
+        UserParticipantProjection userParticipantProjection);
 }

--- a/src/main/java/com/boardgo/domain/mapper/UserInfoMapper.java
+++ b/src/main/java/com/boardgo/domain/mapper/UserInfoMapper.java
@@ -1,18 +1,17 @@
 package com.boardgo.domain.mapper;
 
-import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
 import com.boardgo.domain.review.service.response.MyEvaluationTagsResponse;
 import com.boardgo.domain.user.controller.request.SignupRequest;
 import com.boardgo.domain.user.entity.UserInfoEntity;
 import com.boardgo.domain.user.repository.projection.PersonalInfoProjection;
-import com.boardgo.domain.user.repository.projection.UserParticipantProjection;
 import com.boardgo.domain.user.service.response.OtherPersonalInfoResponse;
 import com.boardgo.domain.user.service.response.UserInfoResponse;
 import com.boardgo.domain.user.service.response.UserPersonalInfoResponse;
 import com.boardgo.oauth2.dto.OAuth2CreateUserRequest;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
 
 @Mapper
 public interface UserInfoMapper {
@@ -30,9 +29,6 @@ public interface UserInfoMapper {
 
     UserPersonalInfoResponse toUserPersonalInfoResponse(
             UserInfoResponse userInfoResponse, Double averageRating);
-
-    UserParticipantResponse toUserParticipantResponse(
-            UserParticipantProjection userParticipantProjection);
 
     OtherPersonalInfoResponse toUserPersonalInfoResponse(
             UserPersonalInfoResponse userPersonalInfoResponse,

--- a/src/main/java/com/boardgo/domain/meeting/controller/MeetingParticipantController.java
+++ b/src/main/java/com/boardgo/domain/meeting/controller/MeetingParticipantController.java
@@ -1,16 +1,11 @@
 package com.boardgo.domain.meeting.controller;
 
-import static com.boardgo.common.constant.HeaderConstant.API_VERSION_HEADER1;
-import static com.boardgo.common.utils.SecurityUtils.currentUserId;
+import static com.boardgo.common.constant.HeaderConstant.*;
+import static com.boardgo.common.utils.SecurityUtils.*;
 
-import com.boardgo.domain.meeting.controller.request.MeetingOutRequest;
-import com.boardgo.domain.meeting.controller.request.MeetingParticipateRequest;
-import com.boardgo.domain.meeting.service.MeetingParticipantCommandUseCase;
-import com.boardgo.domain.meeting.service.MeetingParticipantQueryUseCase;
-import com.boardgo.domain.meeting.service.response.ParticipantOutResponse;
-import jakarta.validation.Valid;
+import java.util.List;
 import java.util.Objects;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +15,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.boardgo.domain.meeting.controller.request.MeetingOutRequest;
+import com.boardgo.domain.meeting.controller.request.MeetingParticipateRequest;
+import com.boardgo.domain.meeting.service.MeetingParticipantCommandUseCase;
+import com.boardgo.domain.meeting.service.MeetingParticipantQueryUseCase;
+import com.boardgo.domain.meeting.service.response.ParticipantOutResponse;
+import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/meeting-participant")
@@ -33,6 +38,11 @@ public class MeetingParticipantController {
             @RequestBody @Valid MeetingParticipateRequest participateRequest) {
         meetingParticipantCommandUseCase.participateMeeting(participateRequest, currentUserId());
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @GetMapping(value = "/{meetingId}", headers = API_VERSION_HEADER1)
+    public ResponseEntity<List<UserParticipantResponse>> getParticipants(@PathVariable("meetingId") Long meetingId) {
+        return ResponseEntity.ok(meetingParticipantQueryUseCase.findByMeetingId(meetingId));
     }
 
     @GetMapping(value = "/out/{meetingId}", headers = API_VERSION_HEADER1)

--- a/src/main/java/com/boardgo/domain/meeting/repository/MeetingParticipantDslRepository.java
+++ b/src/main/java/com/boardgo/domain/meeting/repository/MeetingParticipantDslRepository.java
@@ -1,9 +1,13 @@
 package com.boardgo.domain.meeting.repository;
 
-import com.boardgo.domain.meeting.repository.projection.ReviewMeetingParticipantsProjection;
 import java.util.List;
+
+import com.boardgo.domain.meeting.repository.projection.ReviewMeetingParticipantsProjection;
+import com.boardgo.domain.user.repository.projection.UserParticipantProjection;
 
 public interface MeetingParticipantDslRepository {
     List<ReviewMeetingParticipantsProjection> findReviewMeetingParticipants(
             List<Long> revieweeIds, Long meetingId);
+
+    List<UserParticipantProjection> findParticipantListByMeetingId(Long meetingId);
 }

--- a/src/main/java/com/boardgo/domain/meeting/repository/MeetingParticipantDslRepositoryImpl.java
+++ b/src/main/java/com/boardgo/domain/meeting/repository/MeetingParticipantDslRepositoryImpl.java
@@ -1,16 +1,21 @@
 package com.boardgo.domain.meeting.repository;
 
-import static com.boardgo.domain.meeting.entity.enums.ParticipantType.LEADER;
-import static com.boardgo.domain.meeting.entity.enums.ParticipantType.PARTICIPANT;
+import static com.boardgo.domain.meeting.entity.enums.ParticipantType.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
 
 import com.boardgo.domain.meeting.entity.QMeetingParticipantEntity;
+import com.boardgo.domain.meeting.entity.enums.ParticipantType;
 import com.boardgo.domain.meeting.repository.projection.ReviewMeetingParticipantsProjection;
 import com.boardgo.domain.user.entity.QUserInfoEntity;
+import com.boardgo.domain.user.repository.projection.QUserParticipantProjection;
+import com.boardgo.domain.user.repository.projection.UserParticipantProjection;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import jakarta.persistence.EntityManager;
-import java.util.List;
-import org.springframework.stereotype.Repository;
 
 @Repository
 public class MeetingParticipantDslRepositoryImpl implements MeetingParticipantDslRepository {
@@ -20,6 +25,19 @@ public class MeetingParticipantDslRepositoryImpl implements MeetingParticipantDs
 
     public MeetingParticipantDslRepositoryImpl(EntityManager entityManager) {
         this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<UserParticipantProjection> findParticipantListByMeetingId(Long meetingId) {
+        return    queryFactory
+                .select(
+                    new QUserParticipantProjection(
+                        u.id, u.profileImage, u.nickName, mp.type))
+                .from(u)
+                .innerJoin(mp)
+                .on(mp.userInfoId.eq(u.id))
+                .where(mp.type.ne(ParticipantType.OUT).and(mp.meetingId.eq(meetingId)))
+                .fetch();
     }
 
     @Override

--- a/src/main/java/com/boardgo/domain/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/com/boardgo/domain/meeting/repository/MeetingParticipantRepository.java
@@ -1,16 +1,18 @@
 package com.boardgo.domain.meeting.repository;
 
-import com.boardgo.domain.meeting.entity.MeetingParticipantEntity;
-import com.boardgo.domain.meeting.entity.enums.ParticipantType;
-import com.boardgo.domain.meeting.repository.projection.ParticipationCountProjection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import com.boardgo.domain.meeting.entity.MeetingParticipantEntity;
+import com.boardgo.domain.meeting.entity.enums.ParticipantType;
+import com.boardgo.domain.meeting.repository.projection.ParticipationCountProjection;
 
 @Repository
 public interface MeetingParticipantRepository
@@ -21,7 +23,7 @@ public interface MeetingParticipantRepository
             Long meetingId, Long userId, ParticipantType type);
 
     @Modifying
-    @Query("DELETE FROM MeetingParticipantEntity mp " + "WHERE mp.meetingId = :meetingId")
+    @Query("DELETE FROM MeetingParticipantEntity mp WHERE mp.meetingId = :meetingId")
     int deleteAllInBatchByMeetingId(@Param("meetingId") Long meetingId);
 
     @Query(

--- a/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryServiceV1.java
+++ b/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryServiceV1.java
@@ -2,16 +2,22 @@ package com.boardgo.domain.meeting.service;
 
 import static com.boardgo.domain.meeting.entity.enums.ParticipantType.*;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.boardgo.common.utils.SecurityUtils;
+import com.boardgo.domain.mapper.MeetingParticipantMapper;
 import com.boardgo.domain.meeting.entity.MeetingParticipantEntity;
 import com.boardgo.domain.meeting.entity.enums.ParticipantType;
 import com.boardgo.domain.meeting.repository.MeetingParticipantRepository;
 import com.boardgo.domain.meeting.service.response.ParticipantOutResponse;
-import java.util.List;
-import java.util.Optional;
+import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
+import com.boardgo.domain.user.repository.projection.UserParticipantProjection;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -19,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MeetingParticipantQueryServiceV1 implements MeetingParticipantQueryUseCase {
 
     private final MeetingParticipantRepository meetingParticipantRepository;
+    private final MeetingParticipantMapper meetingParticipantMapper;
 
     @Override
     public ParticipantOutResponse getOutState(Long meetingId) {
@@ -36,5 +43,12 @@ public class MeetingParticipantQueryServiceV1 implements MeetingParticipantQuery
     public int getMeetingCount(Long userId) {
         return meetingParticipantRepository.countByTypeAndUserInfoId(
                 List.of(LEADER, PARTICIPANT), userId);
+    }
+
+    @Override
+    public List<UserParticipantResponse> findByMeetingId(Long meetingId) {
+        List<UserParticipantProjection> projectionList = meetingParticipantRepository.findParticipantListByMeetingId(
+            meetingId);
+        return projectionList.stream().map(meetingParticipantMapper::toUserParticipantResponse).toList();
     }
 }

--- a/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryUseCase.java
+++ b/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryUseCase.java
@@ -1,10 +1,15 @@
 package com.boardgo.domain.meeting.service;
 
+import java.util.List;
+
 import com.boardgo.domain.meeting.service.response.ParticipantOutResponse;
+import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 
 public interface MeetingParticipantQueryUseCase {
 
     ParticipantOutResponse getOutState(Long meetingId);
 
     int getMeetingCount(Long userId);
+
+    List<UserParticipantResponse> findByMeetingId(Long meetingId);
 }

--- a/src/main/java/com/boardgo/domain/meeting/service/facade/MeetingQueryFacadeImpl.java
+++ b/src/main/java/com/boardgo/domain/meeting/service/facade/MeetingQueryFacadeImpl.java
@@ -1,10 +1,21 @@
 package com.boardgo.domain.meeting.service.facade;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.boardgo.common.exception.CustomNoSuchElementException;
 import com.boardgo.domain.boardgame.service.BoardGameQueryUseCase;
 import com.boardgo.domain.mapper.MeetingMapper;
 import com.boardgo.domain.meeting.controller.request.MeetingSearchRequest;
 import com.boardgo.domain.meeting.service.MeetingLikeQueryUseCase;
+import com.boardgo.domain.meeting.service.MeetingParticipantQueryUseCase;
 import com.boardgo.domain.meeting.service.MeetingQueryUseCase;
 import com.boardgo.domain.meeting.service.response.BoardGameByMeetingIdResponse;
 import com.boardgo.domain.meeting.service.response.HomeMeetingDeadlineResponse;
@@ -14,16 +25,8 @@ import com.boardgo.domain.meeting.service.response.MeetingSearchPageResponse;
 import com.boardgo.domain.meeting.service.response.MeetingSearchResponse;
 import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 import com.boardgo.domain.review.service.ReviewQueryUseCase;
-import com.boardgo.domain.user.service.UserQueryUseCase;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -32,7 +35,7 @@ public class MeetingQueryFacadeImpl implements MeetingQueryFacade {
     private final MeetingQueryUseCase meetingQueryUseCase;
     private final MeetingMapper meetingMapper;
     private final BoardGameQueryUseCase boardGameQueryUseCase;
-    private final UserQueryUseCase userQueryUseCase;
+    private final MeetingParticipantQueryUseCase meetingParticipantQueryUseCase;
     private final MeetingLikeQueryUseCase meetingLikeQueryUseCase;
     private final ReviewQueryUseCase reviewQueryUseCase;
 
@@ -69,7 +72,7 @@ public class MeetingQueryFacadeImpl implements MeetingQueryFacade {
         checkNullMeeting(meetingId);
 
         List<UserParticipantResponse> userParticipantResponseList =
-                userQueryUseCase.findByMeetingId(meetingId);
+            meetingParticipantQueryUseCase.findByMeetingId(meetingId);
         List<BoardGameByMeetingIdResponse> boardGameByMeetingIdResponseList =
                 boardGameQueryUseCase.findMeetingDetailByMeetingId(meetingId);
 

--- a/src/main/java/com/boardgo/domain/user/repository/UserDslRepository.java
+++ b/src/main/java/com/boardgo/domain/user/repository/UserDslRepository.java
@@ -1,11 +1,8 @@
 package com.boardgo.domain.user.repository;
 
-import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 import com.boardgo.domain.user.repository.projection.PersonalInfoProjection;
-import java.util.List;
 
 public interface UserDslRepository {
-    List<UserParticipantResponse> findByMeetingId(Long meetingId);
 
     PersonalInfoProjection findByUserInfoId(Long userId);
 }

--- a/src/main/java/com/boardgo/domain/user/repository/UserDslRepositoryImpl.java
+++ b/src/main/java/com/boardgo/domain/user/repository/UserDslRepositoryImpl.java
@@ -2,52 +2,31 @@ package com.boardgo.domain.user.repository;
 
 import static com.querydsl.core.group.GroupBy.*;
 
+import java.util.Map;
+
+import org.springframework.stereotype.Repository;
+
 import com.boardgo.common.exception.CustomNullPointException;
-import com.boardgo.domain.mapper.UserInfoMapper;
-import com.boardgo.domain.meeting.entity.QMeetingParticipantEntity;
-import com.boardgo.domain.meeting.entity.enums.ParticipantType;
-import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 import com.boardgo.domain.user.entity.QUserInfoEntity;
 import com.boardgo.domain.user.entity.QUserPrTagEntity;
 import com.boardgo.domain.user.repository.projection.PersonalInfoProjection;
 import com.boardgo.domain.user.repository.projection.QPersonalInfoProjection;
-import com.boardgo.domain.user.repository.projection.QUserParticipantProjection;
-import com.boardgo.domain.user.repository.projection.UserParticipantProjection;
 import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import jakarta.persistence.EntityManager;
-import java.util.List;
-import java.util.Map;
-import org.springframework.stereotype.Repository;
 
 @Repository
 public class UserDslRepositoryImpl implements UserDslRepository {
     private final JPAQueryFactory queryFactory;
     private final QUserInfoEntity u = QUserInfoEntity.userInfoEntity;
     private final QUserPrTagEntity up = QUserPrTagEntity.userPrTagEntity;
-    private final QMeetingParticipantEntity mp = QMeetingParticipantEntity.meetingParticipantEntity;
-    private final UserInfoMapper userInfoMapper;
 
-    public UserDslRepositoryImpl(EntityManager entityManager, UserInfoMapper userInfoMapper) {
+    public UserDslRepositoryImpl(EntityManager entityManager) {
         this.queryFactory = new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
-        this.userInfoMapper = userInfoMapper;
     }
 
-    @Override
-    public List<UserParticipantResponse> findByMeetingId(Long meetingId) {
-        List<UserParticipantProjection> projectionList =
-                queryFactory
-                        .select(
-                                new QUserParticipantProjection(
-                                        u.id, u.profileImage, u.nickName, mp.type))
-                        .from(u)
-                        .innerJoin(mp)
-                        .on(mp.userInfoId.eq(u.id))
-                        .where(mp.type.ne(ParticipantType.OUT).and(mp.meetingId.eq(meetingId)))
-                        .fetch();
 
-        return projectionList.stream().map(userInfoMapper::toUserParticipantResponse).toList();
-    }
 
     @Override
     public PersonalInfoProjection findByUserInfoId(Long userId) {

--- a/src/main/java/com/boardgo/domain/user/service/UserQueryServiceV1.java
+++ b/src/main/java/com/boardgo/domain/user/service/UserQueryServiceV1.java
@@ -1,21 +1,21 @@
 package com.boardgo.domain.user.service;
 
-import static com.boardgo.common.exception.advice.dto.ErrorCode.DUPLICATE_DATA;
+import static com.boardgo.common.exception.advice.dto.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.boardgo.common.exception.CustomIllegalArgumentException;
 import com.boardgo.common.exception.CustomNullPointException;
 import com.boardgo.domain.mapper.UserInfoMapper;
-import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 import com.boardgo.domain.user.controller.request.EmailRequest;
 import com.boardgo.domain.user.entity.UserInfoEntity;
 import com.boardgo.domain.user.entity.enums.ProviderType;
 import com.boardgo.domain.user.repository.UserRepository;
 import com.boardgo.domain.user.repository.projection.PersonalInfoProjection;
 import com.boardgo.domain.user.service.response.UserInfoResponse;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -50,11 +50,6 @@ public class UserQueryServiceV1 implements UserQueryUseCase {
     public UserInfoResponse getPersonalInfo(Long userId) {
         PersonalInfoProjection personalInfoProjection = userRepository.findByUserInfoId(userId);
         return userInfoMapper.toUserInfoResponse(personalInfoProjection);
-    }
-
-    @Override
-    public List<UserParticipantResponse> findByMeetingId(Long meetingId) {
-        return userRepository.findByMeetingId(meetingId);
     }
 
     @Override

--- a/src/main/java/com/boardgo/domain/user/service/UserQueryUseCase.java
+++ b/src/main/java/com/boardgo/domain/user/service/UserQueryUseCase.java
@@ -1,10 +1,8 @@
 package com.boardgo.domain.user.service;
 
-import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 import com.boardgo.domain.user.controller.request.EmailRequest;
 import com.boardgo.domain.user.entity.UserInfoEntity;
 import com.boardgo.domain.user.service.response.UserInfoResponse;
-import java.util.List;
 
 public interface UserQueryUseCase {
 
@@ -15,8 +13,6 @@ public interface UserQueryUseCase {
     boolean existNickName(String nickName);
 
     UserInfoResponse getPersonalInfo(Long userId);
-
-    List<UserParticipantResponse> findByMeetingId(Long meetingId);
 
     boolean existById(Long id);
 }

--- a/src/test/java/com/boardgo/integration/meeting/service/MeetingParticipantQueryServiceV1Test.java
+++ b/src/test/java/com/boardgo/integration/meeting/service/MeetingParticipantQueryServiceV1Test.java
@@ -1,19 +1,14 @@
 package com.boardgo.integration.meeting.service;
 
-import static com.boardgo.integration.data.MeetingData.getMeetingEntityData;
-import static com.boardgo.integration.fixture.MeetingParticipantFixture.getOutMeetingParticipantEntity;
-import static com.boardgo.integration.fixture.UserInfoFixture.localUserInfoEntity;
+import static com.boardgo.integration.data.MeetingData.*;
+import static com.boardgo.integration.data.UserInfoData.*;
+import static com.boardgo.integration.fixture.MeetingParticipantFixture.*;
+import static com.boardgo.integration.fixture.UserInfoFixture.*;
+import static org.assertj.core.api.Assertions.*;
 
-import com.boardgo.domain.meeting.entity.MeetingEntity;
-import com.boardgo.domain.meeting.entity.MeetingParticipantEntity;
-import com.boardgo.domain.meeting.repository.MeetingParticipantRepository;
-import com.boardgo.domain.meeting.repository.MeetingRepository;
-import com.boardgo.domain.meeting.service.MeetingParticipantQueryUseCase;
-import com.boardgo.domain.meeting.service.response.ParticipantOutResponse;
-import com.boardgo.domain.user.entity.UserInfoEntity;
-import com.boardgo.domain.user.repository.UserRepository;
-import com.boardgo.domain.user.service.response.CustomUserDetails;
-import com.boardgo.integration.support.IntegrationTestSupport;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,12 +18,63 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.boardgo.domain.meeting.entity.MeetingEntity;
+import com.boardgo.domain.meeting.entity.MeetingParticipantEntity;
+import com.boardgo.domain.meeting.entity.enums.ParticipantType;
+import com.boardgo.domain.meeting.repository.MeetingParticipantRepository;
+import com.boardgo.domain.meeting.repository.MeetingRepository;
+import com.boardgo.domain.meeting.service.MeetingParticipantQueryUseCase;
+import com.boardgo.domain.meeting.service.response.ParticipantOutResponse;
+import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
+import com.boardgo.domain.user.entity.UserInfoEntity;
+import com.boardgo.domain.user.repository.UserRepository;
+import com.boardgo.domain.user.service.response.CustomUserDetails;
+import com.boardgo.integration.support.IntegrationTestSupport;
+
 public class MeetingParticipantQueryServiceV1Test extends IntegrationTestSupport {
     @Autowired private UserRepository userRepository;
     @Autowired private MeetingRepository meetingRepository;
     @Autowired private MeetingParticipantRepository meetingParticipantRepository;
 
     @Autowired private MeetingParticipantQueryUseCase meetingParticipantQueryUseCase;
+
+
+    @Test
+    @DisplayName("모임에 참여한 회원 목록을 조회한다")
+    void 모임에_참여한_회원_목록을_조회한다() {
+        // given
+        List<UserInfoEntity> userInfoEntities = new ArrayList<>();
+        int userNumber = 7;
+        for (int i = 0; i < userNumber; i++) {
+            UserInfoEntity userInfo =
+                userInfoEntityData("participate" + i + "@naver.com", "participate" + i).build();
+            userInfoEntities.add(userInfo);
+        }
+        userRepository.saveAll(userInfoEntities);
+
+        Long meetingId = 1L;
+        for (int i = 0; i < userNumber / 2; i++) {
+            meetingParticipantRepository.save(
+                getLeaderMeetingParticipantEntity(meetingId, userInfoEntities.get(i).getId()));
+        }
+        for (int i = 3; i < userNumber - 1; i++) {
+            meetingParticipantRepository.save(
+                getParticipantMeetingParticipantEntity(
+                    meetingId, userInfoEntities.get(i).getId()));
+        }
+        meetingParticipantRepository.save(
+            getOutMeetingParticipantEntity(meetingId, (long) (userNumber)));
+
+        // when
+        List<UserParticipantResponse> userParticipantResponse =
+            meetingParticipantQueryUseCase.findByMeetingId(meetingId);
+
+        // then
+        userParticipantResponse.forEach(
+            userParticipant -> {
+                assertThat(userParticipant.type()).isNotEqualTo(ParticipantType.OUT);
+            });
+    }
 
     @Test
     @DisplayName("방장에 의해 나가진 사용자를 구별할 수 있다")

--- a/src/test/java/com/boardgo/integration/user/service/UserQueryServiceV1Test.java
+++ b/src/test/java/com/boardgo/integration/user/service/UserQueryServiceV1Test.java
@@ -1,20 +1,26 @@
 package com.boardgo.integration.user.service;
 
-import static com.boardgo.integration.data.UserInfoData.userInfoEntityData;
-import static com.boardgo.integration.fixture.MeetingParticipantFixture.getLeaderMeetingParticipantEntity;
-import static com.boardgo.integration.fixture.MeetingParticipantFixture.getOutMeetingParticipantEntity;
-import static com.boardgo.integration.fixture.MeetingParticipantFixture.getParticipantMeetingParticipantEntity;
-import static com.boardgo.integration.fixture.ReviewFixture.getReview;
-import static com.boardgo.integration.fixture.UserInfoFixture.localUserInfoEntity;
-import static com.boardgo.integration.fixture.UserPrTagFixture.userPrTagEntity;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.boardgo.integration.data.UserInfoData.*;
+import static com.boardgo.integration.fixture.MeetingParticipantFixture.*;
+import static com.boardgo.integration.fixture.ReviewFixture.*;
+import static com.boardgo.integration.fixture.UserInfoFixture.*;
+import static com.boardgo.integration.fixture.UserPrTagFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import com.boardgo.common.exception.CustomIllegalArgumentException;
 import com.boardgo.common.exception.CustomNullPointException;
-import com.boardgo.domain.meeting.entity.enums.ParticipantType;
 import com.boardgo.domain.meeting.repository.MeetingParticipantRepository;
-import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 import com.boardgo.domain.review.repository.ReviewRepository;
 import com.boardgo.domain.user.controller.request.EmailRequest;
 import com.boardgo.domain.user.entity.UserInfoEntity;
@@ -28,16 +34,6 @@ import com.boardgo.domain.user.service.response.OtherPersonalInfoResponse;
 import com.boardgo.domain.user.service.response.UserInfoResponse;
 import com.boardgo.domain.user.service.response.UserPersonalInfoResponse;
 import com.boardgo.integration.support.IntegrationTestSupport;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
 
 public class UserQueryServiceV1Test extends IntegrationTestSupport {
     @Autowired private UserRepository userRepository;
@@ -169,42 +165,7 @@ public class UserQueryServiceV1Test extends IntegrationTestSupport {
         assertThat(otherPersonalInfo.meetingCount()).isEqualTo(participationCount);
     }
 
-    @Test
-    @DisplayName("모임에 참여한 회원 목록을 조회한다")
-    void 모임에_참여한_회원_목록을_조회한다() {
-        // given
-        List<UserInfoEntity> userInfoEntities = new ArrayList<>();
-        int userNumber = 7;
-        for (int i = 0; i < userNumber; i++) {
-            UserInfoEntity userInfo =
-                    userInfoEntityData("participate" + i + "@naver.com", "participate" + i).build();
-            userInfoEntities.add(userInfo);
-        }
-        userRepository.saveAll(userInfoEntities);
 
-        Long meetingId = 1L;
-        for (int i = 0; i < userNumber / 2; i++) {
-            meetingParticipantRepository.save(
-                    getLeaderMeetingParticipantEntity(meetingId, userInfoEntities.get(i).getId()));
-        }
-        for (int i = 3; i < userNumber - 1; i++) {
-            meetingParticipantRepository.save(
-                    getParticipantMeetingParticipantEntity(
-                            meetingId, userInfoEntities.get(i).getId()));
-        }
-        meetingParticipantRepository.save(
-                getOutMeetingParticipantEntity(meetingId, (long) (userNumber)));
-
-        // when
-        List<UserParticipantResponse> userParticipantResponse =
-                userQueryUseCase.findByMeetingId(meetingId);
-
-        // then
-        userParticipantResponse.forEach(
-                userParticipant -> {
-                    assertThat(userParticipant.type()).isNotEqualTo(ParticipantType.OUT);
-                });
-    }
 
     private Long getUserId(UserInfoEntity userInfo) {
         UserInfoEntity userInfoEntity = userRepository.save(userInfo);


### PR DESCRIPTION
## PR 유형

어떤 변경 사항이 있나요?

-   [x] 새로운 기능 추가 (테스트 포함)
-   [ ] 버그 수정
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, JavaDocs 추가 및 수정, 문서 추가 및 수정)
-   [ ] 코드 리팩토링 (변수명/클래스명 변경)
-   [ ] 빌드 부분 수정 (yaml, gradle 설정 등)
-   [ ] 파일 혹은 패키지명 수정/삭제
-   [ ] 개발 > 운영 반영 및 conflict 해결

## ✨ 과제 내용

- 채팅 참여자 목록 조회 구현


## 📌 관련 이슈

closed #253 

## 💬리뷰 요구사항(선택)

- 기존에 userQueryService에 있는 부분을 meetingParticipantQueryService로 이동하였습니다. 이게 더 응집성이 있어보였고, response도 meeting쪽에서 사용하고 있더라구요.
```java
    @Override
    public List<UserParticipantResponse> findByMeetingId(Long meetingId) {
        return userRepository.findByMeetingId(meetingId);
    }
```