### PR TITLE
Fix: 리뷰 작성이 필요한 모임목록 조회 이슈 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ dependencies {
 
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    implementation 'com.querydsl:querydsl-sql:5.0.0'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -859,6 +859,7 @@ include::{snippets}/get-evaluation-tags/response-fields.adoc[]
 ==== *요청*
 
 include::{snippets}/get-review-meetings/http-request.adoc[]
+include::{snippets}/get-review-meetings/request-parts.adoc[]
 
 ==== *응답*
 

--- a/src/main/java/com/boardgo/config/JPASQLQueryFactory.java
+++ b/src/main/java/com/boardgo/config/JPASQLQueryFactory.java
@@ -1,0 +1,28 @@
+package com.boardgo.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.jpa.sql.JPASQLQuery;
+import com.querydsl.sql.SQLTemplates;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JPASQLQueryFactory {
+    private final EntityManager entityManager;
+    private final SQLTemplates sqlTemplates;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+    public JPASQLQueryFactory(EntityManager entityManager, SQLTemplates sqlTemplates) {
+        this.entityManager = entityManager;
+        this.sqlTemplates = sqlTemplates;
+    }
+
+    public JPASQLQuery<?> createQuery() {
+        return new JPASQLQuery<>(entityManager, sqlTemplates);
+    }
+}

--- a/src/main/java/com/boardgo/config/SQLTemplatesConfig.java
+++ b/src/main/java/com/boardgo/config/SQLTemplatesConfig.java
@@ -1,0 +1,15 @@
+package com.boardgo.config;
+
+import com.querydsl.sql.MySQLTemplates;
+import com.querydsl.sql.SQLTemplates;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SQLTemplatesConfig {
+
+    @Bean
+    public SQLTemplates sqlTemplates() {
+        return new MySQLTemplates();
+    }
+}

--- a/src/main/java/com/boardgo/domain/mapper/MeetingMapper.java
+++ b/src/main/java/com/boardgo/domain/mapper/MeetingMapper.java
@@ -9,6 +9,7 @@ import com.boardgo.domain.meeting.entity.enums.MeetingType;
 import com.boardgo.domain.meeting.repository.projection.HomeMeetingDeadlineProjection;
 import com.boardgo.domain.meeting.repository.projection.LikedMeetingMyPageProjection;
 import com.boardgo.domain.meeting.repository.projection.MeetingDetailProjection;
+import com.boardgo.domain.meeting.repository.projection.MeetingReviewProjection;
 import com.boardgo.domain.meeting.repository.projection.MeetingSearchProjection;
 import com.boardgo.domain.meeting.repository.projection.MyPageMeetingProjection;
 import com.boardgo.domain.meeting.service.response.HomeMeetingDeadlineResponse;
@@ -20,6 +21,7 @@ import com.boardgo.domain.meeting.service.response.MeetingSearchPageResponse;
 import com.boardgo.domain.meeting.service.response.MeetingSearchResponse;
 import com.boardgo.domain.meeting.service.response.MyPageMeetingResponse;
 import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
+import com.boardgo.domain.review.service.response.ReviewMeetingResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -162,4 +164,7 @@ public interface MeetingMapper {
 
     List<HomeMeetingDeadlineResponse> toHomeMeetingDeadlineResponses(
             List<HomeMeetingDeadlineProjection> homeMeetingDeadlineProjections);
+
+    List<ReviewMeetingResponse> toReviewMeetingResponses(
+            List<MeetingReviewProjection> meetingReviewProjection);
 }

--- a/src/main/java/com/boardgo/domain/mapper/MeetingParticipantMapper.java
+++ b/src/main/java/com/boardgo/domain/mapper/MeetingParticipantMapper.java
@@ -2,12 +2,17 @@ package com.boardgo.domain.mapper;
 
 import com.boardgo.domain.meeting.entity.MeetingParticipantEntity;
 import com.boardgo.domain.meeting.entity.enums.ParticipantType;
+import com.boardgo.domain.meeting.repository.projection.ParticipationCountProjection;
 import com.boardgo.domain.meeting.repository.projection.ReviewMeetingParticipantsProjection;
+import com.boardgo.domain.meeting.service.response.ParticipationCountResponse;
 import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 import com.boardgo.domain.review.service.response.ReviewMeetingParticipantsResponse;
 import com.boardgo.domain.user.repository.projection.UserParticipantProjection;
 import java.util.List;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -22,4 +27,14 @@ public interface MeetingParticipantMapper {
 
     List<ReviewMeetingParticipantsResponse> toReviewMeetingParticipantsList(
             List<ReviewMeetingParticipantsProjection> reviewMeetingParticipantsProjections);
+
+    @IterableMapping(qualifiedByName = "toParticipationCountResponse")
+    List<ParticipationCountResponse> toParticipationCountResponses(
+            List<ParticipationCountProjection> participationCountProjections);
+
+    @Named("toParticipationCountResponse")
+    @Mapping(target = "metingId", source = "meetingId")
+    @Mapping(target = "participationCount", source = "participationCount")
+    ParticipationCountResponse toParticipationCountResponse(
+            ParticipationCountProjection participationCountProjection);
 }

--- a/src/main/java/com/boardgo/domain/mapper/ReviewMapper.java
+++ b/src/main/java/com/boardgo/domain/mapper/ReviewMapper.java
@@ -3,7 +3,6 @@ package com.boardgo.domain.mapper;
 import static com.boardgo.common.utils.CustomStringUtils.longToStringList;
 
 import com.boardgo.domain.meeting.entity.MeetingEntity;
-import com.boardgo.domain.meeting.repository.projection.MeetingReviewProjection;
 import com.boardgo.domain.review.controller.request.ReviewCreateRequest;
 import com.boardgo.domain.review.entity.ReviewEntity;
 import com.boardgo.domain.review.repository.projection.ReviewMeetingReviewsProjection;
@@ -19,11 +18,7 @@ import org.mapstruct.factory.Mappers;
 public interface ReviewMapper {
     BoardGameMapper INSTANCE = Mappers.getMapper(BoardGameMapper.class);
 
-    List<ReviewMeetingResponse> toReviewMeetingReviewMeetingFromEntity(
-            List<MeetingEntity> meetingEntities);
-
-    List<ReviewMeetingResponse> toReviewMeetingReviewMeetingFromProjection(
-            List<MeetingReviewProjection> meetingReviewProjection);
+    List<ReviewMeetingResponse> toReviewMeetingResponses(List<MeetingEntity> meetingEntities);
 
     @Mapping(
             target = "evaluationTags",

--- a/src/main/java/com/boardgo/domain/meeting/repository/MeetingDslRepository.java
+++ b/src/main/java/com/boardgo/domain/meeting/repository/MeetingDslRepository.java
@@ -27,8 +27,8 @@ public interface MeetingDslRepository {
 
     List<LikedMeetingMyPageProjection> findLikedMeeting(List<Long> meetingIdList);
 
-    List<MeetingReviewProjection> findMeetingPreProgressReview(
-            Long reviewer, List<Long> reviewFinishedMeetings);
+    List<MeetingReviewProjection> findReviewableMeeting(
+            Long reviewerId, List<Long> finishedReviewMeetingIds);
 
     long getSearchTotalCount(MeetingSearchRequest searchRequest);
 

--- a/src/main/java/com/boardgo/domain/meeting/repository/MeetingDslRepositoryImpl.java
+++ b/src/main/java/com/boardgo/domain/meeting/repository/MeetingDslRepositoryImpl.java
@@ -1,9 +1,11 @@
 package com.boardgo.domain.meeting.repository;
 
-import static com.boardgo.common.constant.TimeConstant.*;
-import static com.boardgo.domain.meeting.entity.enums.MeetingSortType.*;
-import static com.boardgo.domain.meeting.entity.enums.MeetingState.*;
-import static com.boardgo.domain.meeting.entity.enums.ParticipantType.*;
+import static com.boardgo.common.constant.TimeConstant.REVIEWABLE_HOURS;
+import static com.boardgo.domain.meeting.entity.enums.MeetingSortType.PARTICIPANT_COUNT;
+import static com.boardgo.domain.meeting.entity.enums.MeetingState.FINISH;
+import static com.boardgo.domain.meeting.entity.enums.MeetingState.PROGRESS;
+import static com.boardgo.domain.meeting.entity.enums.ParticipantType.LEADER;
+import static com.boardgo.domain.meeting.entity.enums.ParticipantType.PARTICIPANT;
 
 import com.boardgo.domain.boardgame.entity.QBoardGameEntity;
 import com.boardgo.domain.boardgame.entity.QBoardGameGenreEntity;
@@ -367,8 +369,8 @@ public class MeetingDslRepositoryImpl implements MeetingDslRepository {
     }
 
     @Override
-    public List<MeetingReviewProjection> findMeetingPreProgressReview(
-            Long reviewerId, List<Long> reviewFinishedMeetings) {
+    public List<MeetingReviewProjection> findReviewableMeeting(
+            Long reviewerId, List<Long> finishedReviewMeetingIds) {
         return queryFactory
                 .select(
                         new QMeetingReviewProjection(
@@ -384,7 +386,7 @@ public class MeetingDslRepositoryImpl implements MeetingDslRepository {
                                 .and(
                                         m.meetingDatetime.loe(
                                                 LocalDateTime.now().minusHours(REVIEWABLE_HOURS)))
-                                .and(m.id.notIn(reviewFinishedMeetings)))
+                                .and(m.id.notIn(finishedReviewMeetingIds)))
                 .fetch();
     }
 

--- a/src/main/java/com/boardgo/domain/meeting/repository/MeetingParticipantDslRepository.java
+++ b/src/main/java/com/boardgo/domain/meeting/repository/MeetingParticipantDslRepository.java
@@ -1,5 +1,6 @@
 package com.boardgo.domain.meeting.repository;
 
+import com.boardgo.domain.meeting.repository.projection.MeetingParticipantsCountProjection;
 import com.boardgo.domain.meeting.repository.projection.ReviewMeetingParticipantsProjection;
 import com.boardgo.domain.user.repository.projection.UserParticipantProjection;
 import java.util.List;
@@ -11,4 +12,7 @@ public interface MeetingParticipantDslRepository {
     List<UserParticipantProjection> findParticipantListByMeetingId(Long meetingId);
 
     List<Long> getMeetingIdByNotEqualsOut(Long userId);
+
+    List<MeetingParticipantsCountProjection> countMeetingParticipantsByUserInfoId(
+            Long userId, Long participantCount);
 }

--- a/src/main/java/com/boardgo/domain/meeting/repository/MeetingParticipantDslRepositoryImpl.java
+++ b/src/main/java/com/boardgo/domain/meeting/repository/MeetingParticipantDslRepositoryImpl.java
@@ -4,27 +4,31 @@ import static com.boardgo.domain.meeting.entity.enums.ParticipantType.LEADER;
 import static com.boardgo.domain.meeting.entity.enums.ParticipantType.OUT;
 import static com.boardgo.domain.meeting.entity.enums.ParticipantType.PARTICIPANT;
 
+import com.boardgo.config.JPASQLQueryFactory;
 import com.boardgo.domain.meeting.entity.QMeetingParticipantEntity;
 import com.boardgo.domain.meeting.entity.enums.ParticipantType;
+import com.boardgo.domain.meeting.repository.projection.MeetingParticipantsCountProjection;
 import com.boardgo.domain.meeting.repository.projection.ReviewMeetingParticipantsProjection;
 import com.boardgo.domain.user.entity.QUserInfoEntity;
 import com.boardgo.domain.user.repository.projection.QUserParticipantProjection;
 import com.boardgo.domain.user.repository.projection.UserParticipantProjection;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
+import com.querydsl.sql.SQLExpressions;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@RequiredArgsConstructor
 public class MeetingParticipantDslRepositoryImpl implements MeetingParticipantDslRepository {
     private final JPAQueryFactory queryFactory;
+    private final JPASQLQueryFactory jpasqlQueryFactory;
     private final QMeetingParticipantEntity mp = QMeetingParticipantEntity.meetingParticipantEntity;
     private final QUserInfoEntity u = QUserInfoEntity.userInfoEntity;
-
-    public MeetingParticipantDslRepositoryImpl(EntityManager entityManager) {
-        this.queryFactory = new JPAQueryFactory(entityManager);
-    }
 
     @Override
     public List<UserParticipantProjection> findParticipantListByMeetingId(Long meetingId) {
@@ -66,5 +70,40 @@ public class MeetingParticipantDslRepositoryImpl implements MeetingParticipantDs
                 .from(mp)
                 .where(mp.userInfoId.eq(userId).and(mp.type.ne(OUT)))
                 .fetch();
+    }
+
+    /**
+     * 참여한 모임 별 모임 참여자 수
+     *
+     * @param participantCount null이 아닐 경우 모임 참여자 수가 일치하는 모임 조회
+     * @return Map<모임Id, 모임참여자수>
+     */
+    @Override
+    public List<MeetingParticipantsCountProjection> countMeetingParticipantsByUserInfoId(
+            Long userId, Long participantCount) {
+        StringPath mpSub = Expressions.stringPath("mp_sub");
+
+        return jpasqlQueryFactory
+                .createQuery()
+                .select(
+                        Projections.constructor(
+                                MeetingParticipantsCountProjection.class,
+                                mp.meetingId,
+                                mp.meetingId.count().as("meetingParticipantsCount")))
+                .from(mp)
+                .innerJoin(
+                        SQLExpressions.select(mp.meetingId, mp.type)
+                                .from(mp)
+                                .where(mp.userInfoId.eq(userId)),
+                        mpSub)
+                .on(mp.meetingId.eq(Expressions.numberPath(Long.class, mpSub, "meeting_id")))
+                .where(mp.type.ne(ParticipantType.OUT))
+                .groupBy(mp.meetingId)
+                .having(existParticipantCount(participantCount))
+                .fetch();
+    }
+
+    public BooleanExpression existParticipantCount(Long participantCount) {
+        return participantCount != null ? mp.meetingId.count().eq(participantCount) : null;
     }
 }

--- a/src/main/java/com/boardgo/domain/meeting/repository/projection/MeetingParticipantsCountProjection.java
+++ b/src/main/java/com/boardgo/domain/meeting/repository/projection/MeetingParticipantsCountProjection.java
@@ -1,0 +1,3 @@
+package com.boardgo.domain.meeting.repository.projection;
+
+public record MeetingParticipantsCountProjection(Long meetingId, Long meetingParticipantsCount) {}

--- a/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryServiceV1.java
+++ b/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryServiceV1.java
@@ -12,11 +12,13 @@ import com.boardgo.domain.meeting.entity.enums.ParticipantType;
 import com.boardgo.domain.meeting.repository.MeetingParticipantRepository;
 import com.boardgo.domain.meeting.repository.projection.ReviewMeetingParticipantsProjection;
 import com.boardgo.domain.meeting.service.response.ParticipantOutResponse;
+import com.boardgo.domain.meeting.service.response.ParticipationCountResponse;
 import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 import com.boardgo.domain.review.service.response.ReviewMeetingParticipantsResponse;
 import com.boardgo.domain.user.repository.projection.UserParticipantProjection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -81,5 +83,12 @@ public class MeetingParticipantQueryServiceV1 implements MeetingParticipantQuery
             throw new CustomNoSuchElementException("리뷰를 작성할 참여자");
         }
         return meetingParticipantMapper.toReviewMeetingParticipantsList(reviewMeetingParticipants);
+    }
+
+    @Override
+    public List<ParticipationCountResponse> countMeetingParticipation(
+            Set<Long> meetingIds, List<ParticipantType> types) {
+        return meetingParticipantMapper.toParticipationCountResponses(
+                meetingParticipantRepository.countMeetingParticipation(meetingIds, types));
     }
 }

--- a/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryServiceV1.java
+++ b/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryServiceV1.java
@@ -10,6 +10,7 @@ import com.boardgo.domain.mapper.MeetingParticipantMapper;
 import com.boardgo.domain.meeting.entity.MeetingParticipantEntity;
 import com.boardgo.domain.meeting.entity.enums.ParticipantType;
 import com.boardgo.domain.meeting.repository.MeetingParticipantRepository;
+import com.boardgo.domain.meeting.repository.projection.MeetingParticipantsCountProjection;
 import com.boardgo.domain.meeting.repository.projection.ReviewMeetingParticipantsProjection;
 import com.boardgo.domain.meeting.service.response.ParticipantOutResponse;
 import com.boardgo.domain.meeting.service.response.ParticipationCountResponse;
@@ -17,8 +18,10 @@ import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 import com.boardgo.domain.review.service.response.ReviewMeetingParticipantsResponse;
 import com.boardgo.domain.user.repository.projection.UserParticipantProjection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,9 +89,21 @@ public class MeetingParticipantQueryServiceV1 implements MeetingParticipantQuery
     }
 
     @Override
-    public List<ParticipationCountResponse> countMeetingParticipation(
+    public List<ParticipationCountResponse> countMeetingParticipants(
             Set<Long> meetingIds, List<ParticipantType> types) {
         return meetingParticipantMapper.toParticipationCountResponses(
                 meetingParticipantRepository.countMeetingParticipation(meetingIds, types));
+    }
+
+    @Override
+    public Map<Long, Long> countMeetingParticipants(Long userId, Long participantCount) {
+        List<MeetingParticipantsCountProjection> participantsCounts =
+                meetingParticipantRepository.countMeetingParticipantsByUserInfoId(
+                        userId, participantCount);
+        return participantsCounts.stream()
+                .collect(
+                        Collectors.toMap(
+                                MeetingParticipantsCountProjection::meetingId,
+                                MeetingParticipantsCountProjection::meetingParticipantsCount));
     }
 }

--- a/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryUseCase.java
+++ b/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryUseCase.java
@@ -6,6 +6,7 @@ import com.boardgo.domain.meeting.service.response.ParticipationCountResponse;
 import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 import com.boardgo.domain.review.service.response.ReviewMeetingParticipantsResponse;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public interface MeetingParticipantQueryUseCase {
@@ -23,6 +24,8 @@ public interface MeetingParticipantQueryUseCase {
     List<ReviewMeetingParticipantsResponse> findMeetingParticipantsToReview(
             List<Long> revieweeIds, Long meetingId);
 
-    List<ParticipationCountResponse> countMeetingParticipation(
+    List<ParticipationCountResponse> countMeetingParticipants(
             Set<Long> meetingIds, List<ParticipantType> types);
+
+    Map<Long, Long> countMeetingParticipants(Long userId, Long participantCount);
 }

--- a/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryUseCase.java
+++ b/src/main/java/com/boardgo/domain/meeting/service/MeetingParticipantQueryUseCase.java
@@ -1,9 +1,12 @@
 package com.boardgo.domain.meeting.service;
 
+import com.boardgo.domain.meeting.entity.enums.ParticipantType;
 import com.boardgo.domain.meeting.service.response.ParticipantOutResponse;
+import com.boardgo.domain.meeting.service.response.ParticipationCountResponse;
 import com.boardgo.domain.meeting.service.response.UserParticipantResponse;
 import com.boardgo.domain.review.service.response.ReviewMeetingParticipantsResponse;
 import java.util.List;
+import java.util.Set;
 
 public interface MeetingParticipantQueryUseCase {
 
@@ -19,4 +22,7 @@ public interface MeetingParticipantQueryUseCase {
 
     List<ReviewMeetingParticipantsResponse> findMeetingParticipantsToReview(
             List<Long> revieweeIds, Long meetingId);
+
+    List<ParticipationCountResponse> countMeetingParticipation(
+            Set<Long> meetingIds, List<ParticipantType> types);
 }

--- a/src/main/java/com/boardgo/domain/meeting/service/MeetingQueryServiceV1.java
+++ b/src/main/java/com/boardgo/domain/meeting/service/MeetingQueryServiceV1.java
@@ -14,6 +14,7 @@ import com.boardgo.domain.meeting.service.response.LikedMeetingMyPageResponse;
 import com.boardgo.domain.meeting.service.response.MeetingDetailResponse;
 import com.boardgo.domain.meeting.service.response.MeetingSearchResponse;
 import com.boardgo.domain.meeting.service.response.MyPageMeetingResponse;
+import com.boardgo.domain.review.service.response.ReviewMeetingResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -100,5 +101,17 @@ public class MeetingQueryServiceV1 implements MeetingQueryUseCase {
     public List<LikedMeetingMyPageResponse> findLikedMeeting(List<Long> meetingIdList) {
         return meetingMapper.toLikedMeetingMyPageResponseList(
                 meetingRepository.findLikedMeeting(meetingIdList));
+    }
+
+    @Override
+    public List<MeetingEntity> findAllById(List<Long> meetingIds) {
+        return meetingRepository.findAllById(meetingIds);
+    }
+
+    @Override
+    public List<ReviewMeetingResponse> findReviewableMeeting(
+            Long reviewerId, List<Long> finishedReviewMeetingIds) {
+        return meetingMapper.toReviewMeetingResponses(
+                meetingRepository.findReviewableMeeting(reviewerId, finishedReviewMeetingIds));
     }
 }

--- a/src/main/java/com/boardgo/domain/meeting/service/MeetingQueryUseCase.java
+++ b/src/main/java/com/boardgo/domain/meeting/service/MeetingQueryUseCase.java
@@ -8,6 +8,7 @@ import com.boardgo.domain.meeting.service.response.LikedMeetingMyPageResponse;
 import com.boardgo.domain.meeting.service.response.MeetingDetailResponse;
 import com.boardgo.domain.meeting.service.response.MeetingSearchResponse;
 import com.boardgo.domain.meeting.service.response.MyPageMeetingResponse;
+import com.boardgo.domain.review.service.response.ReviewMeetingResponse;
 import java.util.List;
 import java.util.Map;
 
@@ -37,4 +38,9 @@ public interface MeetingQueryUseCase {
     List<MeetingEntity> findByIdIn(List<Long> meetingIdList);
 
     List<LikedMeetingMyPageResponse> findLikedMeeting(List<Long> meetingIdList);
+
+    List<MeetingEntity> findAllById(List<Long> meetingIds);
+
+    List<ReviewMeetingResponse> findReviewableMeeting(
+            Long reviewerId, List<Long> finishedReviewMeetingIds);
 }

--- a/src/main/java/com/boardgo/domain/meeting/service/response/ParticipationCountResponse.java
+++ b/src/main/java/com/boardgo/domain/meeting/service/response/ParticipationCountResponse.java
@@ -1,0 +1,3 @@
+package com.boardgo.domain.meeting.service.response;
+
+public record ParticipationCountResponse(Long metingId, Integer participationCount) {}

--- a/src/main/java/com/boardgo/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/boardgo/domain/review/controller/ReviewController.java
@@ -43,7 +43,7 @@ public class ReviewController {
             @RequestParam("reviewType") ReviewType reviewType) {
         List<ReviewMeetingResponse> reviewMeetings =
                 reviewQueryFacade.getMeetingsToReview(reviewType, currentUserId());
-        if (Objects.isNull(reviewMeetings)) {
+        if (Objects.isNull(reviewMeetings) || reviewMeetings.isEmpty()) {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(reviewMeetings);

--- a/src/main/java/com/boardgo/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/boardgo/domain/review/controller/ReviewController.java
@@ -15,6 +15,7 @@ import com.boardgo.domain.review.service.response.ReviewMeetingReviewsResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -41,8 +42,8 @@ public class ReviewController {
     public ResponseEntity<List<ReviewMeetingResponse>> getReviewMeetings(
             @RequestParam("reviewType") ReviewType reviewType) {
         List<ReviewMeetingResponse> reviewMeetings =
-                reviewQueryUseCase.getReviewMeetings(reviewType, currentUserId());
-        if (reviewMeetings.isEmpty()) {
+                reviewQueryFacade.getMeetingsToReview(reviewType, currentUserId());
+        if (Objects.isNull(reviewMeetings)) {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(reviewMeetings);

--- a/src/main/java/com/boardgo/domain/review/service/ReviewQueryServiceV1.java
+++ b/src/main/java/com/boardgo/domain/review/service/ReviewQueryServiceV1.java
@@ -1,13 +1,9 @@
 package com.boardgo.domain.review.service;
 
 import static com.boardgo.common.utils.CustomStringUtils.stringToLongList;
-import static com.boardgo.domain.meeting.entity.enums.ParticipantType.LEADER;
-import static com.boardgo.domain.meeting.entity.enums.ParticipantType.PARTICIPANT;
 
 import com.boardgo.common.exception.CustomNoSuchElementException;
 import com.boardgo.domain.mapper.ReviewMapper;
-import com.boardgo.domain.meeting.repository.MeetingParticipantRepository;
-import com.boardgo.domain.meeting.repository.projection.ParticipationCountProjection;
 import com.boardgo.domain.review.entity.EvaluationTagEntity;
 import com.boardgo.domain.review.entity.EvaluationType;
 import com.boardgo.domain.review.repository.EvaluationTagRepository;
@@ -31,7 +27,6 @@ import org.springframework.stereotype.Service;
 public class ReviewQueryServiceV1 implements ReviewQueryUseCase {
 
     private final ReviewRepository reviewRepository;
-    private final MeetingParticipantRepository meetingParticipantRepository;
     private final ReviewMapper reviewMapper;
     private final EvaluationTagRepository evaluationTagRepository;
 
@@ -46,35 +41,18 @@ public class ReviewQueryServiceV1 implements ReviewQueryUseCase {
     }
 
     /***
-     * 참여한 모임에서 참여자 모두에게 리뷰를 작성한 모임 찾기
-     * @return 리뷰 작성 완료 모임 ID 목록
+     * 모임 별로 리뷰 작성 갯수 카운팅
+     * @return Map<모임Id, 리뷰작성갯수>
      */
     @Override
-    public List<Long> findFinishedReviewMeetingIds(Long userId) {
+    public Map<Long, Integer> countReview(Long userId) {
         List<ReviewCountProjection> reviewCountList =
                 reviewRepository.countReviewByReviewerId(userId);
-
-        Map<Long, Integer> reviewCountMap =
-                reviewCountList.stream()
-                        .collect(
-                                Collectors.toMap(
-                                        ReviewCountProjection::getMeetingId,
-                                        ReviewCountProjection::getReviewCount));
-
-        List<ParticipationCountProjection> participationCountList =
-                meetingParticipantRepository.countMeetingParticipation(
-                        reviewCountMap.keySet(), List.of(LEADER, PARTICIPANT));
-
-        List<Long> reviewFinished = new ArrayList<>();
-        for (ParticipationCountProjection participationCount : participationCountList) {
-            Long meetingId = participationCount.getMeetingId();
-            Integer reviewCount = reviewCountMap.get(meetingId);
-            Integer participantCount = participationCount.getParticipationCount() - 1; // 본인 제외
-            if (reviewCount.equals(participantCount)) {
-                reviewFinished.add(meetingId);
-            }
-        }
-        return reviewFinished;
+        return reviewCountList.stream()
+                .collect(
+                        Collectors.toMap(
+                                ReviewCountProjection::getMeetingId,
+                                ReviewCountProjection::getReviewCount));
     }
 
     @Override

--- a/src/main/java/com/boardgo/domain/review/service/ReviewQueryServiceV1.java
+++ b/src/main/java/com/boardgo/domain/review/service/ReviewQueryServiceV1.java
@@ -6,14 +6,10 @@ import static com.boardgo.domain.meeting.entity.enums.ParticipantType.PARTICIPAN
 
 import com.boardgo.common.exception.CustomNoSuchElementException;
 import com.boardgo.domain.mapper.ReviewMapper;
-import com.boardgo.domain.meeting.entity.MeetingEntity;
 import com.boardgo.domain.meeting.repository.MeetingParticipantRepository;
-import com.boardgo.domain.meeting.repository.MeetingRepository;
-import com.boardgo.domain.meeting.repository.projection.MeetingReviewProjection;
 import com.boardgo.domain.meeting.repository.projection.ParticipationCountProjection;
 import com.boardgo.domain.review.entity.EvaluationTagEntity;
 import com.boardgo.domain.review.entity.EvaluationType;
-import com.boardgo.domain.review.entity.enums.ReviewType;
 import com.boardgo.domain.review.repository.EvaluationTagRepository;
 import com.boardgo.domain.review.repository.ReviewRepository;
 import com.boardgo.domain.review.repository.projection.MyEvaluationTagProjection;
@@ -22,7 +18,6 @@ import com.boardgo.domain.review.repository.projection.ReviewMeetingReviewsProje
 import com.boardgo.domain.review.service.response.MyEvaluationTagResponse;
 import com.boardgo.domain.review.service.response.MyEvaluationTagsResponse;
 import com.boardgo.domain.review.service.response.MyReviewsResponse;
-import com.boardgo.domain.review.service.response.ReviewMeetingResponse;
 import com.boardgo.domain.review.service.response.ReviewMeetingReviewsResponse;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,39 +31,26 @@ import org.springframework.stereotype.Service;
 public class ReviewQueryServiceV1 implements ReviewQueryUseCase {
 
     private final ReviewRepository reviewRepository;
-    private final MeetingRepository meetingRepository;
     private final MeetingParticipantRepository meetingParticipantRepository;
     private final ReviewMapper reviewMapper;
     private final EvaluationTagRepository evaluationTagRepository;
 
-    // FIXME: 퍼사드패턴으로 리팩토링 필요
+    /***
+     * 모임을 함께 한 참여자에게 리뷰를 작성할 경우 모임 id 가 조회된다.
+     * (참여자 모두에게 리뷰를 작성하지 않아도 조회 됨)
+     * @return 참여자에게 리뷰를 작성한 모임 id 목록
+     */
     @Override
-    public List<ReviewMeetingResponse> getReviewMeetings(ReviewType reviewType, Long userId) {
-        switch (reviewType) {
-            case PRE_PROGRESS -> {
-                List<Long> reviewFinishedMeetings = findReviewFinishedList(userId);
-                List<MeetingReviewProjection> meetingPreProgressReview =
-                        meetingRepository.findMeetingPreProgressReview(
-                                userId, reviewFinishedMeetings);
-                return reviewMapper.toReviewMeetingReviewMeetingFromProjection(
-                        meetingPreProgressReview);
-            }
-            case FINISH -> {
-                List<Long> meetingIds = reviewRepository.findFinishedReview(userId);
-                List<MeetingEntity> meetingEntityList = meetingRepository.findAllById(meetingIds);
-                return reviewMapper.toReviewMeetingReviewMeetingFromEntity(meetingEntityList);
-            }
-        }
-
-        return List.of();
+    public List<Long> findMeetingIdsOfWrittenReview(Long userId) {
+        return reviewRepository.findFinishedReview(userId);
     }
 
     /***
-     * 참여한 모임애서 참여자 모두에게 리뷰를 작성한 모임 찾기
-     * @param userId
+     * 참여한 모임에서 참여자 모두에게 리뷰를 작성한 모임 찾기
      * @return 리뷰 작성 완료 모임 ID 목록
      */
-    private List<Long> findReviewFinishedList(Long userId) {
+    @Override
+    public List<Long> findFinishedReviewMeetingIds(Long userId) {
         List<ReviewCountProjection> reviewCountList =
                 reviewRepository.countReviewByReviewerId(userId);
 

--- a/src/main/java/com/boardgo/domain/review/service/ReviewQueryUseCase.java
+++ b/src/main/java/com/boardgo/domain/review/service/ReviewQueryUseCase.java
@@ -4,12 +4,13 @@ import com.boardgo.domain.review.service.response.MyEvaluationTagsResponse;
 import com.boardgo.domain.review.service.response.MyReviewsResponse;
 import com.boardgo.domain.review.service.response.ReviewMeetingReviewsResponse;
 import java.util.List;
+import java.util.Map;
 
 public interface ReviewQueryUseCase {
 
     List<Long> findMeetingIdsOfWrittenReview(Long userId);
 
-    List<Long> findFinishedReviewMeetingIds(Long userId);
+    Map<Long, Integer> countReview(Long userId);
 
     List<Long> getReviewMeetingParticipants(Long meetingId, Long reviewerId);
 

--- a/src/main/java/com/boardgo/domain/review/service/ReviewQueryUseCase.java
+++ b/src/main/java/com/boardgo/domain/review/service/ReviewQueryUseCase.java
@@ -1,15 +1,15 @@
 package com.boardgo.domain.review.service;
 
-import com.boardgo.domain.review.entity.enums.ReviewType;
 import com.boardgo.domain.review.service.response.MyEvaluationTagsResponse;
 import com.boardgo.domain.review.service.response.MyReviewsResponse;
-import com.boardgo.domain.review.service.response.ReviewMeetingResponse;
 import com.boardgo.domain.review.service.response.ReviewMeetingReviewsResponse;
 import java.util.List;
 
 public interface ReviewQueryUseCase {
 
-    List<ReviewMeetingResponse> getReviewMeetings(ReviewType reviewType, Long userId);
+    List<Long> findMeetingIdsOfWrittenReview(Long userId);
+
+    List<Long> findFinishedReviewMeetingIds(Long userId);
 
     List<Long> getReviewMeetingParticipants(Long meetingId, Long reviewerId);
 

--- a/src/main/java/com/boardgo/domain/review/service/facade/ReviewQueryFacade.java
+++ b/src/main/java/com/boardgo/domain/review/service/facade/ReviewQueryFacade.java
@@ -1,10 +1,14 @@
 package com.boardgo.domain.review.service.facade;
 
+import com.boardgo.domain.review.entity.enums.ReviewType;
 import com.boardgo.domain.review.service.response.ReviewMeetingParticipantsResponse;
+import com.boardgo.domain.review.service.response.ReviewMeetingResponse;
 import java.util.List;
 
 public interface ReviewQueryFacade {
 
     List<ReviewMeetingParticipantsResponse> getMeetingParticipantsToReview(
             Long meetingId, Long reviewerId);
+
+    List<ReviewMeetingResponse> getMeetingsToReview(ReviewType reviewType, Long userId);
 }

--- a/src/main/java/com/boardgo/domain/review/service/facade/ReviewQueryFacadeImpl.java
+++ b/src/main/java/com/boardgo/domain/review/service/facade/ReviewQueryFacadeImpl.java
@@ -1,8 +1,13 @@
 package com.boardgo.domain.review.service.facade;
 
+import com.boardgo.domain.mapper.ReviewMapper;
+import com.boardgo.domain.meeting.entity.MeetingEntity;
 import com.boardgo.domain.meeting.service.MeetingParticipantQueryUseCase;
+import com.boardgo.domain.meeting.service.MeetingQueryUseCase;
+import com.boardgo.domain.review.entity.enums.ReviewType;
 import com.boardgo.domain.review.service.ReviewQueryUseCase;
 import com.boardgo.domain.review.service.response.ReviewMeetingParticipantsResponse;
+import com.boardgo.domain.review.service.response.ReviewMeetingResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,6 +17,8 @@ import org.springframework.stereotype.Component;
 public class ReviewQueryFacadeImpl implements ReviewQueryFacade {
     private final ReviewQueryUseCase reviewQueryUseCase;
     private final MeetingParticipantQueryUseCase meetingParticipantQueryUseCase;
+    private final MeetingQueryUseCase meetingQueryUseCase;
+    private final ReviewMapper reviewMapper;
 
     @Override
     public List<ReviewMeetingParticipantsResponse> getMeetingParticipantsToReview(
@@ -21,5 +28,22 @@ public class ReviewQueryFacadeImpl implements ReviewQueryFacade {
         revieweeIds.add(reviewerId); // 본인 리뷰 작성자 목록 표출 제외
         return meetingParticipantQueryUseCase.findMeetingParticipantsToReview(
                 revieweeIds, meetingId);
+    }
+
+    @Override
+    public List<ReviewMeetingResponse> getMeetingsToReview(ReviewType reviewType, Long userId) {
+        switch (reviewType) {
+            case PRE_PROGRESS -> {
+                List<Long> finishedReviewMeetingIds =
+                        reviewQueryUseCase.findFinishedReviewMeetingIds(userId);
+                return meetingQueryUseCase.findReviewableMeeting(userId, finishedReviewMeetingIds);
+            }
+            case FINISH -> {
+                List<Long> meetingIds = reviewQueryUseCase.findMeetingIdsOfWrittenReview(userId);
+                List<MeetingEntity> meetingEntityList = meetingQueryUseCase.findAllById(meetingIds);
+                return reviewMapper.toReviewMeetingResponses(meetingEntityList);
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/boardgo/domain/review/service/facade/ReviewQueryFacadeImpl.java
+++ b/src/main/java/com/boardgo/domain/review/service/facade/ReviewQueryFacadeImpl.java
@@ -1,14 +1,20 @@
 package com.boardgo.domain.review.service.facade;
 
+import static com.boardgo.domain.meeting.entity.enums.ParticipantType.LEADER;
+import static com.boardgo.domain.meeting.entity.enums.ParticipantType.PARTICIPANT;
+
 import com.boardgo.domain.mapper.ReviewMapper;
 import com.boardgo.domain.meeting.entity.MeetingEntity;
 import com.boardgo.domain.meeting.service.MeetingParticipantQueryUseCase;
 import com.boardgo.domain.meeting.service.MeetingQueryUseCase;
+import com.boardgo.domain.meeting.service.response.ParticipationCountResponse;
 import com.boardgo.domain.review.entity.enums.ReviewType;
 import com.boardgo.domain.review.service.ReviewQueryUseCase;
 import com.boardgo.domain.review.service.response.ReviewMeetingParticipantsResponse;
 import com.boardgo.domain.review.service.response.ReviewMeetingResponse;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -34,8 +40,7 @@ public class ReviewQueryFacadeImpl implements ReviewQueryFacade {
     public List<ReviewMeetingResponse> getMeetingsToReview(ReviewType reviewType, Long userId) {
         switch (reviewType) {
             case PRE_PROGRESS -> {
-                List<Long> finishedReviewMeetingIds =
-                        reviewQueryUseCase.findFinishedReviewMeetingIds(userId);
+                List<Long> finishedReviewMeetingIds = findFinishedReviewMeetingIds(userId);
                 return meetingQueryUseCase.findReviewableMeeting(userId, finishedReviewMeetingIds);
             }
             case FINISH -> {
@@ -45,5 +50,29 @@ public class ReviewQueryFacadeImpl implements ReviewQueryFacade {
             }
         }
         return null;
+    }
+
+    /***
+     * 모임 별로 참여자 모두에게 리뷰를 전부 작성한 모임 찾기
+     * (리뷰 작성이 필요없는 모임)
+     * @return 리뷰 작성 완료 모임 ID 목록
+     */
+    public List<Long> findFinishedReviewMeetingIds(Long userId) {
+        Map<Long, Integer> reviewCountMap = reviewQueryUseCase.countReview(userId);
+
+        List<ParticipationCountResponse> participationCountList =
+                meetingParticipantQueryUseCase.countMeetingParticipation(
+                        reviewCountMap.keySet(), List.of(LEADER, PARTICIPANT));
+
+        List<Long> reviewFinished = new ArrayList<>();
+        for (ParticipationCountResponse participationCount : participationCountList) {
+            Long meetingId = participationCount.metingId();
+            Integer reviewCount = reviewCountMap.get(meetingId);
+            Integer participantCount = participationCount.participationCount() - 1; // 본인 제외
+            if (reviewCount.equals(participantCount)) {
+                reviewFinished.add(meetingId);
+            }
+        }
+        return reviewFinished;
     }
 }

--- a/src/main/java/com/boardgo/domain/review/service/facade/ReviewQueryFacadeImpl.java
+++ b/src/main/java/com/boardgo/domain/review/service/facade/ReviewQueryFacadeImpl.java
@@ -41,6 +41,10 @@ public class ReviewQueryFacadeImpl implements ReviewQueryFacade {
         switch (reviewType) {
             case PRE_PROGRESS -> {
                 List<Long> finishedReviewMeetingIds = findFinishedReviewMeetingIds(userId);
+                // 모임 중 참여자가 본인 1명 뿐인 경우 리뷰 작성 모임 항목에서 제외
+                Map<Long, Long> meetingParticipantsCount =
+                        meetingParticipantQueryUseCase.countMeetingParticipants(userId, 1L);
+                finishedReviewMeetingIds.addAll(meetingParticipantsCount.keySet());
                 return meetingQueryUseCase.findReviewableMeeting(userId, finishedReviewMeetingIds);
             }
             case FINISH -> {
@@ -61,7 +65,7 @@ public class ReviewQueryFacadeImpl implements ReviewQueryFacade {
         Map<Long, Integer> reviewCountMap = reviewQueryUseCase.countReview(userId);
 
         List<ParticipationCountResponse> participationCountList =
-                meetingParticipantQueryUseCase.countMeetingParticipation(
+                meetingParticipantQueryUseCase.countMeetingParticipants(
                         reviewCountMap.keySet(), List.of(LEADER, PARTICIPANT));
 
         List<Long> reviewFinished = new ArrayList<>();

--- a/src/test/java/com/boardgo/integration/meeting/service/MeetingParticipantQueryServiceV1Test.java
+++ b/src/test/java/com/boardgo/integration/meeting/service/MeetingParticipantQueryServiceV1Test.java
@@ -26,6 +26,7 @@ import com.boardgo.domain.user.service.response.CustomUserDetails;
 import com.boardgo.integration.support.IntegrationTestSupport;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -200,5 +201,49 @@ public class MeetingParticipantQueryServiceV1Test extends IntegrationTestSupport
                         tuple(
                                 userInfoEntities.get(2).getId(),
                                 userInfoEntities.get(2).getNickName()));
+    }
+
+    @Test
+    @DisplayName("내가 참여한 모임의 참여자 수 조회하기")
+    void 내가_참여한_모임의_참여자_수_조회하기() {
+        // given
+        Long user1 = 1L;
+        for (long i = 1; i <= 5; i++) {
+            meetingParticipantRepository.save(getParticipantMeetingParticipantEntity(i, user1));
+        }
+        Long user2 = 2L;
+        meetingParticipantRepository.save(getParticipantMeetingParticipantEntity(1L, user2));
+        Long user3 = 3L;
+        meetingParticipantRepository.save(getParticipantMeetingParticipantEntity(1L, user3));
+        meetingParticipantRepository.save(getParticipantMeetingParticipantEntity(2L, user3));
+
+        // when
+        Map<Long, Long> count =
+                meetingParticipantQueryUseCase.countMeetingParticipants(user1, null);
+
+        // then
+        assertThat(count.keySet()).containsExactlyInAnyOrder(1L, 2L, 3L, 4L, 5L);
+        assertThat(count.values()).containsExactlyInAnyOrder(3L, 2L, 1L, 1L, 1L);
+    }
+
+    @Test
+    @DisplayName("내가 참여한 모임 중 특정 참여자 수인 모임만 조회하기")
+    void 내가_참여한_모임_중_특정_참여자_수인_모임만_조회하기() {
+        // given
+        Long user1 = 1L;
+        for (long i = 1; i <= 5; i++) {
+            meetingParticipantRepository.save(getParticipantMeetingParticipantEntity(i, user1));
+        }
+        Long user2 = 2L;
+        meetingParticipantRepository.save(getParticipantMeetingParticipantEntity(1L, user2));
+        meetingParticipantRepository.save(getParticipantMeetingParticipantEntity(2L, user2));
+        // when
+        long targetNum = 1L;
+        Map<Long, Long> count =
+                meetingParticipantQueryUseCase.countMeetingParticipants(user1, targetNum);
+
+        // then
+        assertThat(count.keySet()).doesNotContain(1L, 2L).containsExactlyInAnyOrder(3L, 4L, 5L);
+        assertThat(count.values()).containsExactly(targetNum, targetNum, targetNum);
     }
 }

--- a/src/test/java/com/boardgo/integration/review/facade/ReviewQueryFacadeTest.java
+++ b/src/test/java/com/boardgo/integration/review/facade/ReviewQueryFacadeTest.java
@@ -1,0 +1,211 @@
+package com.boardgo.integration.review.facade;
+
+import static com.boardgo.common.constant.TimeConstant.REVIEWABLE_HOURS;
+import static com.boardgo.domain.review.entity.enums.ReviewType.PRE_PROGRESS;
+import static com.boardgo.integration.data.MeetingData.getMeetingEntityData;
+import static com.boardgo.integration.data.UserInfoData.userInfoEntityData;
+import static com.boardgo.integration.fixture.MeetingParticipantFixture.getLeaderMeetingParticipantEntity;
+import static com.boardgo.integration.fixture.MeetingParticipantFixture.getOutMeetingParticipantEntity;
+import static com.boardgo.integration.fixture.MeetingParticipantFixture.getParticipantMeetingParticipantEntity;
+import static com.boardgo.integration.fixture.ReviewFixture.getReview;
+import static com.boardgo.integration.fixture.UserInfoFixture.localUserInfoEntity;
+import static com.boardgo.integration.fixture.UserInfoFixture.socialUserInfoEntity;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.boardgo.domain.meeting.entity.MeetingEntity;
+import com.boardgo.domain.meeting.entity.enums.MeetingState;
+import com.boardgo.domain.meeting.repository.MeetingParticipantRepository;
+import com.boardgo.domain.meeting.repository.MeetingRepository;
+import com.boardgo.domain.review.repository.ReviewRepository;
+import com.boardgo.domain.review.service.facade.ReviewQueryFacade;
+import com.boardgo.domain.review.service.response.ReviewMeetingResponse;
+import com.boardgo.domain.user.entity.UserInfoEntity;
+import com.boardgo.domain.user.entity.enums.ProviderType;
+import com.boardgo.domain.user.repository.UserRepository;
+import com.boardgo.integration.support.IntegrationTestSupport;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ReviewQueryFacadeTest extends IntegrationTestSupport {
+    @Autowired private ReviewQueryFacade reviewQueryFacade;
+    @Autowired private UserRepository userRepository;
+    @Autowired private MeetingRepository meetingRepository;
+    @Autowired private ReviewRepository reviewRepository;
+    @Autowired private MeetingParticipantRepository meetingParticipantRepository;
+
+    @Test
+    @DisplayName("강퇴된 모임은 리뷰 모임 목록에 존재할 수 없다")
+    void 강퇴된_모임은_리뷰_모임_목록에_존재할_수_없다() {
+        // given
+        UserInfoEntity participant = userRepository.save(localUserInfoEntity());
+        Long meetingId = participateMeetingData();
+        meetingParticipantRepository.save(
+                getOutMeetingParticipantEntity(meetingId, participant.getId()));
+
+        // when
+        List<ReviewMeetingResponse> reviewMeetingList =
+                reviewQueryFacade.getMeetingsToReview(PRE_PROGRESS, participant.getId());
+
+        // then
+        assertThat(reviewMeetingList).isEmpty();
+    }
+
+    @Test
+    @DisplayName("모임이 종료된 지 3시간 이후된 모임만 리뷰 모임 목록에 존재한다")
+    void 모임이_종료된_지_3시간_이후된_모임만_리뷰_모임_목록에_존재한다() {
+        // given
+        UserInfoEntity participant = userRepository.save(localUserInfoEntity());
+        Long meetingId = participateMeetingData();
+        meetingParticipantRepository.save(
+                getParticipantMeetingParticipantEntity(meetingId, participant.getId()));
+        // 모집중인 모임 추가
+        UserInfoEntity leader =
+                userRepository.save(userInfoEntityData("leader@email.com", "myname").build());
+        meetingRepository.save(getMeetingEntityData(leader.getId()).build());
+
+        // when
+        List<ReviewMeetingResponse> reviewMeetingList =
+                reviewQueryFacade.getMeetingsToReview(PRE_PROGRESS, participant.getId());
+
+        // then
+        assertThat(reviewMeetingList).isNotEmpty();
+        for (ReviewMeetingResponse reviewMeeting : reviewMeetingList) {
+            assertThat(reviewMeeting.meetingDatetime()).isBefore(LocalDateTime.now());
+
+            LocalDateTime reviewableDatetime =
+                    reviewMeeting.meetingDatetime().plusHours(REVIEWABLE_HOURS);
+            assertThat(reviewableDatetime).isBeforeOrEqualTo(LocalDateTime.now());
+        }
+    }
+
+    @Test
+    @DisplayName("모임이 종료되었지만, 모임 날짜가 현재로 부터 3시간이 지나지 않았을 경우 리뷰 목록에 표출되지 않는다")
+    void 모임이_종료되었지만_모임_날짜가_현재로_부터_3시간이_지나지_않았을_경우_리뷰_목록에_표출되지_않는다() {
+        // given
+        // 회원
+        UserInfoEntity participant = userRepository.save(localUserInfoEntity());
+        UserInfoEntity leader = userRepository.save(socialUserInfoEntity(ProviderType.KAKAO));
+        // 모임
+        MeetingEntity meeting =
+                meetingRepository.save(
+                        getMeetingEntityData(leader.getId())
+                                .meetingDatetime(LocalDateTime.now())
+                                .state(MeetingState.FINISH)
+                                .build());
+        // 모임참가
+        meetingParticipantRepository.save(
+                getLeaderMeetingParticipantEntity(meeting.getId(), leader.getId()));
+        meetingParticipantRepository.save(
+                getParticipantMeetingParticipantEntity(meeting.getId(), participant.getId()));
+
+        // when
+        List<ReviewMeetingResponse> reviewMeetingList =
+                reviewQueryFacade.getMeetingsToReview(PRE_PROGRESS, participant.getId());
+
+        // then
+        assertThat(reviewMeetingList).isEmpty();
+
+        LocalDateTime reviewableDatetime = meeting.getMeetingDatetime().plusHours(REVIEWABLE_HOURS);
+        assertThat(reviewableDatetime).isAfterOrEqualTo(LocalDateTime.now());
+    }
+
+    @Test
+    @DisplayName("모임에 참가한 참여자에게 모두 리뷰를 작성했을 경우 작성할 리뷰 모임 목록에 존재하지 않는다")
+    void 모임에_참가한_참여자에게_모두_리뷰를_작성했을_경우_작성할_리뷰_모임_목록에_존재하지_않는다() {
+        // given
+        UserInfoEntity me = userRepository.save(localUserInfoEntity()); // 1L
+        Long meetingId = participateMeetingData();
+
+        // 참여자
+        UserInfoEntity participant1 =
+                userRepository.save(
+                        userInfoEntityData("participant1@email.com", "participant1").build());
+        UserInfoEntity participant2 =
+                userRepository.save(
+                        userInfoEntityData("participant2@email.com", "participant2").build());
+        UserInfoEntity participant3 =
+                userRepository.save(
+                        userInfoEntityData("participant3@email.com", "participant3").build());
+        // 모임참가(5명)
+        meetingParticipantRepository.save(
+                getParticipantMeetingParticipantEntity(meetingId, me.getId()));
+        meetingParticipantRepository.save(
+                getParticipantMeetingParticipantEntity(meetingId, participant1.getId()));
+        meetingParticipantRepository.save(
+                getParticipantMeetingParticipantEntity(meetingId, participant2.getId()));
+        meetingParticipantRepository.save(
+                getParticipantMeetingParticipantEntity(meetingId, participant3.getId()));
+        // 리뷰(본인제외 모임참여저 5명 중 4명에게 리뷰 작성)
+        Long leader = 2L;
+        reviewRepository.save(getReview(me.getId(), leader, meetingId));
+        reviewRepository.save(getReview(me.getId(), participant1.getId(), meetingId));
+        reviewRepository.save(getReview(me.getId(), participant2.getId(), meetingId));
+        reviewRepository.save(getReview(me.getId(), participant3.getId(), meetingId));
+
+        // when
+        List<ReviewMeetingResponse> reviewMeetingList =
+                reviewQueryFacade.getMeetingsToReview(PRE_PROGRESS, me.getId());
+
+        // then
+        assertThat(reviewMeetingList).isEmpty();
+    }
+
+    @Test
+    @DisplayName("모임에 참가한 참여자에게 모두 리뷰를 작성하지 않으면 작성할 리뷰 모임 목록에 존재한다")
+    void 모임에_참가한_참여자에게_모두_리뷰를_작성하지_않으면_작성할_리뷰_모임_목록에_존재한다() {
+        // given
+        UserInfoEntity me = userRepository.save(localUserInfoEntity()); // 1L
+        Long meetingId = participateMeetingData();
+
+        // 참여자
+        UserInfoEntity participant1 =
+                userRepository.save(
+                        userInfoEntityData("participant1@email.com", "participant1").build());
+        UserInfoEntity participant2 =
+                userRepository.save(
+                        userInfoEntityData("participant2@email.com", "participant2").build());
+        UserInfoEntity participant3 =
+                userRepository.save(
+                        userInfoEntityData("participant3@email.com", "participant3").build());
+        // 모임참가(총 5명)
+        meetingParticipantRepository.save(
+                getParticipantMeetingParticipantEntity(meetingId, me.getId()));
+        meetingParticipantRepository.save(
+                getParticipantMeetingParticipantEntity(meetingId, participant1.getId()));
+        meetingParticipantRepository.save(
+                getParticipantMeetingParticipantEntity(meetingId, participant2.getId()));
+        meetingParticipantRepository.save(
+                getParticipantMeetingParticipantEntity(meetingId, participant3.getId()));
+        // 리뷰(본인제외 모임참여저 5명 중 3명에게 리뷰 작성)
+        reviewRepository.save(getReview(me.getId(), participant1.getId(), meetingId));
+        reviewRepository.save(getReview(me.getId(), participant2.getId(), meetingId));
+        reviewRepository.save(getReview(me.getId(), participant3.getId(), meetingId));
+
+        // when
+        List<ReviewMeetingResponse> reviewMeetingList =
+                reviewQueryFacade.getMeetingsToReview(PRE_PROGRESS, me.getId());
+
+        // then
+        assertThat(reviewMeetingList).isNotEmpty();
+        assertThat(reviewMeetingList.getFirst().id()).isEqualTo(meetingId);
+    }
+
+    private Long participateMeetingData() {
+        // 회원
+        UserInfoEntity leader = userRepository.save(socialUserInfoEntity(ProviderType.KAKAO));
+        // 모임
+        MeetingEntity meeting =
+                meetingRepository.save(
+                        getMeetingEntityData(leader.getId())
+                                .meetingDatetime(LocalDateTime.now().minusDays(1))
+                                .state(MeetingState.FINISH)
+                                .build());
+        // 모임참가
+        meetingParticipantRepository.save(
+                getLeaderMeetingParticipantEntity(meeting.getId(), leader.getId()));
+        return meeting.getId();
+    }
+}

--- a/src/test/java/com/boardgo/integration/review/service/ReviewQueryServiceV1Test.java
+++ b/src/test/java/com/boardgo/integration/review/service/ReviewQueryServiceV1Test.java
@@ -1,34 +1,16 @@
 package com.boardgo.integration.review.service;
 
-import static com.boardgo.common.constant.TimeConstant.REVIEWABLE_HOURS;
-import static com.boardgo.domain.review.entity.enums.ReviewType.PRE_PROGRESS;
-import static com.boardgo.integration.data.MeetingData.getMeetingEntityData;
-import static com.boardgo.integration.data.UserInfoData.userInfoEntityData;
 import static com.boardgo.integration.fixture.EvaluationTagFixture.getEvaluationTagEntity;
-import static com.boardgo.integration.fixture.MeetingParticipantFixture.getLeaderMeetingParticipantEntity;
-import static com.boardgo.integration.fixture.MeetingParticipantFixture.getOutMeetingParticipantEntity;
-import static com.boardgo.integration.fixture.MeetingParticipantFixture.getParticipantMeetingParticipantEntity;
 import static com.boardgo.integration.fixture.ReviewFixture.getReview;
-import static com.boardgo.integration.fixture.UserInfoFixture.localUserInfoEntity;
-import static com.boardgo.integration.fixture.UserInfoFixture.socialUserInfoEntity;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.boardgo.domain.meeting.entity.MeetingEntity;
-import com.boardgo.domain.meeting.entity.enums.MeetingState;
-import com.boardgo.domain.meeting.repository.MeetingParticipantRepository;
-import com.boardgo.domain.meeting.repository.MeetingRepository;
 import com.boardgo.domain.review.entity.ReviewEntity;
 import com.boardgo.domain.review.repository.EvaluationTagRepository;
 import com.boardgo.domain.review.repository.ReviewRepository;
 import com.boardgo.domain.review.service.ReviewQueryUseCase;
 import com.boardgo.domain.review.service.response.MyEvaluationTagResponse;
 import com.boardgo.domain.review.service.response.MyReviewsResponse;
-import com.boardgo.domain.review.service.response.ReviewMeetingResponse;
-import com.boardgo.domain.user.entity.UserInfoEntity;
-import com.boardgo.domain.user.entity.enums.ProviderType;
-import com.boardgo.domain.user.repository.UserRepository;
 import com.boardgo.integration.support.IntegrationTestSupport;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -38,184 +20,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class ReviewQueryServiceV1Test extends IntegrationTestSupport {
 
     @Autowired private ReviewQueryUseCase reviewQueryUseCase;
-    @Autowired private UserRepository userRepository;
-    @Autowired private MeetingRepository meetingRepository;
     @Autowired private ReviewRepository reviewRepository;
-    @Autowired private MeetingParticipantRepository meetingParticipantRepository;
     @Autowired private EvaluationTagRepository evaluationTagRepository;
-
-    @Test
-    @DisplayName("강퇴된 모임은 리뷰 모임 목록에 존재할 수 없다")
-    void 강퇴된_모임은_리뷰_모임_목록에_존재할_수_없다() {
-        // given
-        UserInfoEntity participant = userRepository.save(localUserInfoEntity());
-        Long meetingId = participateMeetingData();
-        meetingParticipantRepository.save(
-                getOutMeetingParticipantEntity(meetingId, participant.getId()));
-
-        // when
-        List<ReviewMeetingResponse> reviewMeetingList =
-                reviewQueryUseCase.getReviewMeetings(PRE_PROGRESS, participant.getId());
-
-        // then
-        assertThat(reviewMeetingList).isEmpty();
-    }
-
-    @Test
-    @DisplayName("모임이 종료된 지 3시간 이후된 모임만 리뷰 모임 목록에 존재한다")
-    void 모임이_종료된_지_3시간_이후된_모임만_리뷰_모임_목록에_존재한다() {
-        // given
-        UserInfoEntity participant = userRepository.save(localUserInfoEntity());
-        Long meetingId = participateMeetingData();
-        meetingParticipantRepository.save(
-                getParticipantMeetingParticipantEntity(meetingId, participant.getId()));
-        // 모집중인 모임 추가
-        UserInfoEntity leader =
-                userRepository.save(userInfoEntityData("leader@email.com", "myname").build());
-        meetingRepository.save(getMeetingEntityData(leader.getId()).build());
-
-        // when
-        List<ReviewMeetingResponse> reviewMeetingList =
-                reviewQueryUseCase.getReviewMeetings(PRE_PROGRESS, participant.getId());
-
-        // then
-        assertThat(reviewMeetingList).isNotEmpty();
-        for (ReviewMeetingResponse reviewMeeting : reviewMeetingList) {
-            assertThat(reviewMeeting.meetingDatetime()).isBefore(LocalDateTime.now());
-
-            LocalDateTime reviewableDatetime =
-                    reviewMeeting.meetingDatetime().plusHours(REVIEWABLE_HOURS);
-            assertThat(reviewableDatetime).isBeforeOrEqualTo(LocalDateTime.now());
-        }
-    }
-
-    @Test
-    @DisplayName("모임이 종료되었지만, 모임 날짜가 현재로 부터 3시간이 지나지 않았을 경우 리뷰 목록에 표출되지 않는다")
-    void 모임이_종료되었지만_모임_날짜가_현재로_부터_3시간이_지나지_않았을_경우_리뷰_목록에_표출되지_않는다() {
-        // given
-        // 회원
-        UserInfoEntity participant = userRepository.save(localUserInfoEntity());
-        UserInfoEntity leader = userRepository.save(socialUserInfoEntity(ProviderType.KAKAO));
-        // 모임
-        MeetingEntity meeting =
-                meetingRepository.save(
-                        getMeetingEntityData(leader.getId())
-                                .meetingDatetime(LocalDateTime.now())
-                                .state(MeetingState.FINISH)
-                                .build());
-        // 모임참가
-        meetingParticipantRepository.save(
-                getLeaderMeetingParticipantEntity(meeting.getId(), leader.getId()));
-        meetingParticipantRepository.save(
-                getParticipantMeetingParticipantEntity(meeting.getId(), participant.getId()));
-
-        // when
-        List<ReviewMeetingResponse> reviewMeetingList =
-                reviewQueryUseCase.getReviewMeetings(PRE_PROGRESS, participant.getId());
-
-        // then
-        assertThat(reviewMeetingList).isEmpty();
-
-        LocalDateTime reviewableDatetime = meeting.getMeetingDatetime().plusHours(REVIEWABLE_HOURS);
-        assertThat(reviewableDatetime).isAfterOrEqualTo(LocalDateTime.now());
-    }
-
-    @Test
-    @DisplayName("모임에 참가한 참여자에게 모두 리뷰를 작성했을 경우 작성할 리뷰 모임 목록에 존재하지 않는다")
-    void 모임에_참가한_참여자에게_모두_리뷰를_작성했을_경우_작성할_리뷰_모임_목록에_존재하지_않는다() {
-        // given
-        UserInfoEntity me = userRepository.save(localUserInfoEntity()); // 1L
-        Long meetingId = participateMeetingData();
-
-        // 참여자
-        UserInfoEntity participant1 =
-                userRepository.save(
-                        userInfoEntityData("participant1@email.com", "participant1").build());
-        UserInfoEntity participant2 =
-                userRepository.save(
-                        userInfoEntityData("participant2@email.com", "participant2").build());
-        UserInfoEntity participant3 =
-                userRepository.save(
-                        userInfoEntityData("participant3@email.com", "participant3").build());
-        // 모임참가(5명)
-        meetingParticipantRepository.save(
-                getParticipantMeetingParticipantEntity(meetingId, me.getId()));
-        meetingParticipantRepository.save(
-                getParticipantMeetingParticipantEntity(meetingId, participant1.getId()));
-        meetingParticipantRepository.save(
-                getParticipantMeetingParticipantEntity(meetingId, participant2.getId()));
-        meetingParticipantRepository.save(
-                getParticipantMeetingParticipantEntity(meetingId, participant3.getId()));
-        // 리뷰(본인제외 모임참여저 5명 중 4명에게 리뷰 작성)
-        Long leader = 2L;
-        reviewRepository.save(getReview(me.getId(), leader, meetingId));
-        reviewRepository.save(getReview(me.getId(), participant1.getId(), meetingId));
-        reviewRepository.save(getReview(me.getId(), participant2.getId(), meetingId));
-        reviewRepository.save(getReview(me.getId(), participant3.getId(), meetingId));
-
-        // when
-        List<ReviewMeetingResponse> reviewMeetingList =
-                reviewQueryUseCase.getReviewMeetings(PRE_PROGRESS, me.getId());
-
-        // then
-        assertThat(reviewMeetingList).isEmpty();
-    }
-
-    @Test
-    @DisplayName("모임에 참가한 참여자에게 모두 리뷰를 작성하지 않으면 작성할 리뷰 모임 목록에 존재한다")
-    void 모임에_참가한_참여자에게_모두_리뷰를_작성하지_않으면_작성할_리뷰_모임_목록에_존재한다() {
-        // given
-        UserInfoEntity me = userRepository.save(localUserInfoEntity()); // 1L
-        Long meetingId = participateMeetingData();
-
-        // 참여자
-        UserInfoEntity participant1 =
-                userRepository.save(
-                        userInfoEntityData("participant1@email.com", "participant1").build());
-        UserInfoEntity participant2 =
-                userRepository.save(
-                        userInfoEntityData("participant2@email.com", "participant2").build());
-        UserInfoEntity participant3 =
-                userRepository.save(
-                        userInfoEntityData("participant3@email.com", "participant3").build());
-        // 모임참가(총 5명)
-        meetingParticipantRepository.save(
-                getParticipantMeetingParticipantEntity(meetingId, me.getId()));
-        meetingParticipantRepository.save(
-                getParticipantMeetingParticipantEntity(meetingId, participant1.getId()));
-        meetingParticipantRepository.save(
-                getParticipantMeetingParticipantEntity(meetingId, participant2.getId()));
-        meetingParticipantRepository.save(
-                getParticipantMeetingParticipantEntity(meetingId, participant3.getId()));
-        // 리뷰(본인제외 모임참여저 5명 중 3명에게 리뷰 작성)
-        reviewRepository.save(getReview(me.getId(), participant1.getId(), meetingId));
-        reviewRepository.save(getReview(me.getId(), participant2.getId(), meetingId));
-        reviewRepository.save(getReview(me.getId(), participant3.getId(), meetingId));
-
-        // when
-        List<ReviewMeetingResponse> reviewMeetingList =
-                reviewQueryUseCase.getReviewMeetings(PRE_PROGRESS, me.getId());
-
-        // then
-        assertThat(reviewMeetingList).isNotEmpty();
-        assertThat(reviewMeetingList.getFirst().id()).isEqualTo(meetingId);
-    }
-
-    private Long participateMeetingData() {
-        // 회원
-        UserInfoEntity leader = userRepository.save(socialUserInfoEntity(ProviderType.KAKAO));
-        // 모임
-        MeetingEntity meeting =
-                meetingRepository.save(
-                        getMeetingEntityData(leader.getId())
-                                .meetingDatetime(LocalDateTime.now().minusDays(1))
-                                .state(MeetingState.FINISH)
-                                .build());
-        // 모임참가
-        meetingParticipantRepository.save(
-                getLeaderMeetingParticipantEntity(meeting.getId(), leader.getId()));
-        return meeting.getId();
-    }
 
     @Test
     @DisplayName("내 평가태그 조회 시 모든 모임에서 받은 각 평가태그의 갯수를 합산해서 보여준다")


### PR DESCRIPTION
## PR 유형

어떤 변경 사항이 있나요?

-   [ ] 새로운 기능 추가 (테스트 포함)
-   [x] 버그 수정
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, JavaDocs 추가 및 수정, 문서 추가 및 수정)
-   [x] 코드 리팩토링 (변수명/클래스명 변경)
-   [ ] 빌드 부분 수정 (yaml, gradle 설정 등)
-   [ ] 파일 혹은 패키지명 수정/삭제
-   [ ] 개발 > 운영 반영 및 conflict 해결

## ✨ 과제 내용
- 리뷰 작성이 필요한 모임목록 조회 이슈 수정
리뷰 작성이 필요한 모임목록 조회 시 참여자가 본인 1명만 있는 모임의 경우 리뷰 작성할 모임에서 제외 시키기
- /my/review/meetings API 퍼사드 패턴으로 리팩토링

## 📌 관련 이슈
[Fix: 리뷰 작성이 필요한 모임목록 조회 이슈 수정](https://github.com/LuckyVicky-2team/backend/pull/284/commits/459bd304778ca5732cdfcd0acfc76f7bb884aa19)
[Feat: 참여한 모임 중 특정 참여자 수인 모임 조회 기능 통합테스트 코드 작성](https://github.com/LuckyVicky-2team/backend/pull/284/commits/76f8d41d488e397539c9d010ed0918d8d0c7eb6b)
