### PR TITLE
Fix: 모임 상세/목록에 모임의 상태가 변경되지 않는 이슈

### DIFF
--- a/src/main/java/com/boardgo/domain/meeting/service/facade/MeetingParticipantCommandFacadeImpl.java
+++ b/src/main/java/com/boardgo/domain/meeting/service/facade/MeetingParticipantCommandFacadeImpl.java
@@ -1,8 +1,12 @@
 package com.boardgo.domain.meeting.service.facade;
 
+import static com.boardgo.domain.meeting.entity.enums.MeetingState.COMPLETE;
+import static com.boardgo.domain.meeting.entity.enums.MeetingState.PROGRESS;
 import static com.boardgo.domain.notification.entity.MessageType.KICKED_OUT;
 
+import com.boardgo.domain.meeting.entity.MeetingEntity;
 import com.boardgo.domain.meeting.service.MeetingParticipantCommandUseCase;
+import com.boardgo.domain.meeting.service.MeetingQueryUseCase;
 import com.boardgo.domain.notification.service.facade.NotificationCommandFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,11 +15,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MeetingParticipantCommandFacadeImpl implements MeetingParticipantCommandFacade {
     private final MeetingParticipantCommandUseCase meetingParticipantCommandUseCase;
+    private final MeetingQueryUseCase meetingQueryUseCase;
     private final NotificationCommandFacade notificationCommandFacade;
 
     @Override
     public void outMeeting(Long meetingId, Long userId, boolean isKicked) {
         meetingParticipantCommandUseCase.outMeeting(meetingId, userId);
+        MeetingEntity meeting = meetingQueryUseCase.getMeeting(meetingId);
+        if (COMPLETE.equals(meeting.getState())) {
+            meeting.updateMeetingState(PROGRESS);
+        }
         if (isKicked) {
             notificationCommandFacade.create(meetingId, userId, KICKED_OUT);
         }

--- a/src/test/java/com/boardgo/config/MeetingParticipantCommandFacadeConfig.java
+++ b/src/test/java/com/boardgo/config/MeetingParticipantCommandFacadeConfig.java
@@ -1,0 +1,18 @@
+package com.boardgo.config;
+
+import static org.mockito.Mockito.mock;
+
+import com.boardgo.domain.meeting.service.MeetingParticipantCommandUseCase;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@TestConfiguration
+public class MeetingParticipantCommandFacadeConfig {
+
+    @Bean
+    @Primary
+    public MeetingParticipantCommandUseCase meetingParticipantCommandUseCase() {
+        return mock(MeetingParticipantCommandUseCase.class);
+    }
+}

--- a/src/test/java/com/boardgo/integration/meeting/service/MeetingQueryFacadeImplTest.java
+++ b/src/test/java/com/boardgo/integration/meeting/service/MeetingQueryFacadeImplTest.java
@@ -1,8 +1,10 @@
 package com.boardgo.integration.meeting.service;
 
-import static com.boardgo.domain.meeting.entity.enums.MeetingState.*;
-import static com.boardgo.integration.data.MeetingData.*;
-import static org.assertj.core.api.Assertions.*;
+import static com.boardgo.domain.meeting.entity.enums.MeetingState.COMPLETE;
+import static com.boardgo.domain.meeting.entity.enums.MeetingState.FINISH;
+import static com.boardgo.domain.meeting.entity.enums.MeetingState.PROGRESS;
+import static com.boardgo.integration.data.MeetingData.getMeetingEntityData;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.boardgo.domain.boardgame.service.response.BoardGameListResponse;
 import com.boardgo.domain.meeting.controller.request.MeetingSearchRequest;
@@ -255,13 +257,12 @@ public class MeetingQueryFacadeImplTest extends IntegrationTestSupport {
         meetingLikeRepository.save(
                 MeetingLikeEntity.builder().meetingId(meetingEntity.getId()).userId(3L).build());
 
-        MeetingParticipantEntity savedParticipant =
-                meetingParticipantRepository.save(
-                        MeetingParticipantEntity.builder()
-                                .meetingId(meetingId)
-                                .userInfoId(2L)
-                                .type(ParticipantType.PARTICIPANT)
-                                .build());
+        meetingParticipantRepository.save(
+                MeetingParticipantEntity.builder()
+                        .meetingId(meetingId)
+                        .userInfoId(2L)
+                        .type(ParticipantType.PARTICIPANT)
+                        .build());
 
         // when
         MeetingResponse result = meetingQueryFacade.getDetailById(meetingId, 1L);


### PR DESCRIPTION
## PR 유형

어떤 변경 사항이 있나요?

-   [ ] 새로운 기능 추가 (테스트 포함)
-   [x] 버그 수정
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, JavaDocs 추가 및 수정, 문서 추가 및 수정)
-   [x] 코드 리팩토링 (변수명/클래스명 변경)
-   [ ] 빌드 부분 수정 (yaml, gradle 설정 등)
-   [ ] 파일 혹은 패키지명 수정/삭제
-   [ ] 개발 > 운영 반영 및 conflict 해결

## ✨ 과제 내용
－ 모임 상세/목록에 모임의 상태가 변경되지 않는 이슈 처리
모임 나가기/강퇴하기 시 모임의 상태 변경하도록 수정